### PR TITLE
Actively transform the scene when the view is dragged

### DIFF
--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -9,6 +9,7 @@ from chandra_aca.transform import (
     yagzag_to_pixels,
     yagzag_to_radec,
 )
+from proseco.acq import get_acq_candidates_mask
 from PyQt5 import QtCore as QtC
 from PyQt5 import QtGui as QtG
 from PyQt5 import QtWidgets as QtW
@@ -37,6 +38,7 @@ class Star(QtW.QGraphicsEllipseItem):
         s = symsize(star["MAG_ACA"])
         rect = QtC.QRectF(-s / 2, -s / 2, s, s)
         super().__init__(rect, parent)
+        # self._stars = Table([star], names=star.colnames, dtype=star.dtype)
         self.star = star
         self.highlight = highlight
         color = self.color()
@@ -64,22 +66,7 @@ class Star(QtW.QGraphicsEllipseItem):
         return QtG.QColor("black")
 
     def bad(self):
-        ok = (
-            (self.star["CLASS"] == 0)
-            & (self.star["MAG_ACA"] > 5.3)
-            & (self.star["MAG_ACA"] < 11.0)
-            & (~np.isclose(self.star["COLOR1"], 0.7))
-            & (self.star["MAG_ACA_ERR"] < 100.0)  # mag_err is in 0.01 mag
-            & (self.star["ASPQ1"] < 40)
-            & (  # Less than 2 arcsec centroid offset due to nearby spoiler
-                self.star["ASPQ2"] == 0
-            )
-            & (self.star["POS_ERR"] < 3000)  # Position error < 3.0 arcsec
-            & (
-                (self.star["VAR"] == -9999) | (self.star["VAR"] == 5)
-            )  # Not known to vary > 0.2 mag
-        )
-        return not ok
+        return not get_acq_candidates_mask(self.star)
 
     def text(self):
         return (

--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -23,6 +23,7 @@ __all__ = [
     "MonBox",
 ]
 
+
 def symsize(mag):
     # map mags to figsizes, defining
     # mag 6 as 40 and mag 11 as 3
@@ -147,9 +148,7 @@ class Catalog(QtW.QGraphicsItem):
             yag, zag = radec_to_yagzag(
                 item.starcat_row["ra"], item.starcat_row["dec"], attitude
             )
-            row, col = yagzag_to_pixels(
-                yag, zag, allow_bad=True
-            )
+            row, col = yagzag_to_pixels(yag, zag, allow_bad=True)
             # item.setPos(-yag, -zag)
             item.setPos(row, -col)
 
@@ -232,4 +231,3 @@ class MonBox(QtW.QGraphicsRectItem):
         super().__init__(-(hw * 2), -(hw * 2), hw * 4, hw * 4, parent)
         self.setPen(QtG.QPen(QtG.QColor(255, 165, 0), w))
         self.setPos(star["row"], -star["col"])
-

--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -1,0 +1,235 @@
+"""
+Collection of QGraphicsItem subclasses to represent star field items in the star field view.
+"""
+
+import numpy as np
+from astropy.table import Table
+from chandra_aca.transform import (
+    radec_to_yagzag,
+    yagzag_to_pixels,
+    yagzag_to_radec,
+)
+from PyQt5 import QtCore as QtC
+from PyQt5 import QtGui as QtG
+from PyQt5 import QtWidgets as QtW
+
+__all__ = [
+    "Star",
+    "Catalog",
+    "FidLight",
+    "StarcatLabel",
+    "GuideStar",
+    "AcqStar",
+    "MonBox",
+]
+
+def symsize(mag):
+    # map mags to figsizes, defining
+    # mag 6 as 40 and mag 11 as 3
+    # interp should leave it at the bounding value outside
+    # the range
+    return np.interp(mag, [6.0, 11.0], [32.0, 8.0])
+
+
+class Star(QtW.QGraphicsEllipseItem):
+    def __init__(self, star, parent=None, highlight=False):
+        s = symsize(star["MAG_ACA"])
+        rect = QtC.QRectF(-s / 2, -s / 2, s, s)
+        super().__init__(rect, parent)
+        self.star = star
+        self.highlight = highlight
+        color = self.color()
+        self.setBrush(QtG.QBrush(color))
+        self.setPen(QtG.QPen(color))
+        self.included = {
+            "acq": None,
+            "guide": None,
+        }
+        # stars are stacked in z by magnitude, so small stars never hide behind big ones
+        # the brightest entry in the catalog has MAG_ACA = -1.801
+        # the faintest entry in the catalog has MAG_ACA ~ 21.5
+        self.setZValue(20 + star["MAG_ACA"])
+
+    def __repr__(self):
+        return f"Star({self.star['AGASC_ID']})"
+
+    def color(self):
+        if self.highlight:
+            return QtG.QColor("red")
+        if self.star["MAG_ACA"] > 10.5:
+            return QtG.QColor("lightGray")
+        if self.bad():
+            return QtG.QColor(255, 99, 71, 191)
+        return QtG.QColor("black")
+
+    def bad(self):
+        ok = (
+            (self.star["CLASS"] == 0)
+            & (self.star["MAG_ACA"] > 5.3)
+            & (self.star["MAG_ACA"] < 11.0)
+            & (~np.isclose(self.star["COLOR1"], 0.7))
+            & (self.star["MAG_ACA_ERR"] < 100.0)  # mag_err is in 0.01 mag
+            & (self.star["ASPQ1"] < 40)
+            & (  # Less than 2 arcsec centroid offset due to nearby spoiler
+                self.star["ASPQ2"] == 0
+            )
+            & (self.star["POS_ERR"] < 3000)  # Position error < 3.0 arcsec
+            & (
+                (self.star["VAR"] == -9999) | (self.star["VAR"] == 5)
+            )  # Not known to vary > 0.2 mag
+        )
+        return not ok
+
+    def text(self):
+        return (
+            "<pre>"
+            f"ID:      {self.star['AGASC_ID']}\n"
+            f"mag:     {self.star['MAG_ACA']:.2f} +- {self.star['MAG_ACA_ERR']/100:.2}\n"
+            f"color:   {self.star['COLOR1']:.2f}\n"
+            f"ASPQ1:   {self.star['ASPQ1']}\n"
+            f"ASPQ2:   {self.star['ASPQ2']}\n"
+            f"class:   {self.star['CLASS']}\n"
+            f"pos err: {self.star['POS_ERR']/1000} mas\n"
+            f"VAR:     {self.star['VAR']}"
+            "</pre>"
+        )
+
+
+class Catalog(QtW.QGraphicsItem):
+    """
+    Utility class to keep together all graphics item for a star catalog.
+
+    Note that the position of the catalog is ALLWAYS (0,0) and the item positions need to be set
+    separately for a given attitude.
+    """
+
+    def __init__(self, catalog, parent=None):
+        super().__init__(parent)
+        self.starcat = catalog.copy()  # will add some columns
+
+        cat = Table(self.starcat)
+        # item positions are set from row/col
+        cat["row"], cat["col"] = yagzag_to_pixels(
+            cat["yang"], cat["zang"], allow_bad=True
+        )
+        # when attitude changes, the positions (row, col) are recalculated from (ra, dec)
+        # so these items move with the corresponding star.
+        cat["ra"], cat["dec"] = yagzag_to_radec(
+            cat["yang"], cat["zang"], self.starcat.att
+        )
+        gui_stars = cat[(cat["type"] == "GUI") | (cat["type"] == "BOT")]
+        acq_stars = cat[(cat["type"] == "ACQ") | (cat["type"] == "BOT")]
+        fids = cat[cat["type"] == "FID"]
+        mon_wins = cat[cat["type"] == "MON"]
+
+        self.star_labels = [StarcatLabel(star, self) for star in cat]
+        self.guide_stars = [GuideStar(gui_star, self) for gui_star in gui_stars]
+        self.acq_stars = [AcqStar(acq_star, self) for acq_star in acq_stars]
+        self.mon_stars = [MonBox(mon_box, self) for mon_box in mon_wins]
+        self.fid_lights = [FidLight(fid, self) for fid in fids]
+
+    def setPos(self, *_args, **_kwargs):
+        # the position of the catalog is ALLWAYS (0,0)
+        pass
+
+    def set_pos_for_attitude(self, attitude):
+        """
+        Set the position of all items in the catalog for a given attitude.
+
+        Calling QGraphicsItem.set_pos would not work. Children positions are relative to the
+        parent, but in reality the relative distances between items changes with the attitude.
+        One cannot change the position of a single item and then get the rest as a relative shift.
+        Each item needs to be set individually.
+        """
+        # item positions are relative to the parent's position (self)
+        # but the parent's position is (or should be) always (0, 0)
+        for item in self.childItems():
+            yag, zag = radec_to_yagzag(
+                item.starcat_row["ra"], item.starcat_row["dec"], attitude
+            )
+            row, col = yagzag_to_pixels(
+                yag, zag, allow_bad=True
+            )
+            # item.setPos(-yag, -zag)
+            item.setPos(row, -col)
+
+    def boundingRect(self):
+        return QtC.QRectF(0, 0, 1, 1)
+
+    def paint(self, _painter, _option, _widget):
+        # this item draws nothing, it just holds children
+        pass
+
+    def __repr__(self):
+        return repr(self.starcat)
+
+
+class FidLight(QtW.QGraphicsEllipseItem):
+    def __init__(self, fid, parent=None):
+        self.starcat_row = fid
+        s = 27
+        w = 3
+        rect = QtC.QRectF(-s, -s, 2 * s, 2 * s)
+        super().__init__(rect, parent)
+        self.fid = fid
+        pen = QtG.QPen(QtG.QColor("red"), w)
+        self.setPen(pen)
+        # self.setPos(-fid["yang"], -fid["zang"])
+        self.setPos(fid["row"], -fid["col"])
+
+        line = QtW.QGraphicsLineItem(-s, 0, s, 0, self)
+        line.setPen(pen)
+        line = QtW.QGraphicsLineItem(0, -s, 0, s, self)
+        line.setPen(pen)
+
+
+class StarcatLabel(QtW.QGraphicsTextItem):
+    def __init__(self, star, parent=None):
+        self.starcat_row = star
+        super().__init__(f"{star['idx']}", parent)
+        self._offset = 30
+        self.setFont(QtG.QFont("Arial", 30))
+        self.setDefaultTextColor(QtG.QColor("red"))
+        # self.setPos(-star["yang"], -star["zang"])
+        self.setPos(star["row"], -star["col"])
+
+    def setPos(self, x, y):
+        rect = self.boundingRect()
+        super().setPos(
+            x + self._offset - rect.width() / 2, y - self._offset - rect.height() / 2
+        )
+
+
+class GuideStar(QtW.QGraphicsEllipseItem):
+    def __init__(self, star, parent=None):
+        self.starcat_row = star
+        s = 27
+        w = 5
+        rect = QtC.QRectF(-s, -s, s * 2, s * 2)
+        super().__init__(rect, parent)
+        self.setPen(QtG.QPen(QtG.QColor("green"), w))
+        # self.setPos(-star["yang"], -star["zang"])
+        self.setPos(star["row"], -star["col"])
+
+
+class AcqStar(QtW.QGraphicsRectItem):
+    def __init__(self, star, parent=None):
+        self.starcat_row = star
+        hw = star["halfw"] / 5
+        w = 5
+        super().__init__(-hw, -hw, hw * 2, hw * 2, parent)
+        self.setPen(QtG.QPen(QtG.QColor("blue"), w))
+        # self.setPos(-star["yang"], -star["zang"])
+        self.setPos(star["row"], -star["col"])
+
+
+class MonBox(QtW.QGraphicsRectItem):
+    def __init__(self, star, parent=None):
+        self.starcat_row = star
+        # starcheck convention was to plot monitor boxes at 2X halfw
+        hw = star["halfw"] / 5
+        w = 5
+        super().__init__(-(hw * 2), -(hw * 2), hw * 4, hw * 4, parent)
+        self.setPen(QtG.QPen(QtG.QColor(255, 165, 0), w))
+        self.setPos(star["row"], -star["col"])
+

--- a/aperoll/utils.py
+++ b/aperoll/utils.py
@@ -1,7 +1,67 @@
+import numpy as np
+from chandra_aca.transform import pixels_to_yagzag, yagzag_to_pixels
 from ska_helpers import logging
 
 logger = logging.basic_logger("aperoll")
 
 
+# The nominal origin of the CCD, in pixel coordinates (yagzag_to_pixels(0, 0))
+CCD_ORIGIN = yagzag_to_pixels(
+    0, 0
+)  # (6.08840495576943, 4.92618563916467) as of this writing
+# The (0,0) point of the CCD coordinates in (yag, zag)
+YZ_ORIGIN = pixels_to_yagzag(0, 0)
+
+
 class AperollException(RuntimeError):
     pass
+
+
+def get_camera_fov_frame():
+    """
+    Paths that correspond ot the edges of the ACA CCD and the quadrant boundaries.
+    """
+    frame = {}
+    N = 100
+    edge_1 = np.array(
+        [[-520, i] for i in np.linspace(-512, 512, N)]
+        + [[i, 512] for i in np.linspace(-520, 520, N)]
+        + [[520, i] for i in np.linspace(512, -512, N)]
+        + [[i, -512] for i in np.linspace(520, -520, N)]
+        + [[-520, 0]]
+    ).T
+    frame["edge_1"] = {
+        "row": edge_1[0],
+        "col": edge_1[1],
+    }
+
+    edge_2 = np.array(
+        [[-512, i] for i in np.linspace(-512, 512, N)]
+        + [[i, 512] for i in np.linspace(-512, 512, N)]
+        + [[512, i] for i in np.linspace(512, -512, N)]
+        + [[i, -512] for i in np.linspace(512, -512, N)]
+        + [[-512, 0]]
+    ).T
+    frame["edge_2"] = {
+        "row": edge_2[0],
+        "col": edge_2[1],
+    }
+
+    cross_2 = np.array([[i, 0] for i in np.linspace(-511, 511, N)]).T
+    frame["cross_2"] = {
+        "row": cross_2[0],
+        "col": cross_2[1],
+    }
+
+    cross_1 = np.array([[0, i] for i in np.linspace(-511, 511, N)]).T
+    frame["cross_1"] = {
+        "row": cross_1[0],
+        "col": cross_1[1],
+    }
+
+    for key in frame:
+        frame[key]["yag"], frame[key]["zag"] = pixels_to_yagzag(
+            frame[key]["row"], frame[key]["col"], allow_bad=True
+        )
+
+    return frame

--- a/aperoll/widgets/main_window.py
+++ b/aperoll/widgets/main_window.py
@@ -179,7 +179,7 @@ class MainWindow(QtW.QMainWindow):
                 sparkles.core.check_catalog(aca)
 
         if starcat is not None:
-            self.plot.set_catalog(starcat, update=False)
+            self.plot.set_catalog(starcat)
             self.starcat_view.set_catalog(aca)
 
     def closeEvent(self, event):
@@ -199,8 +199,8 @@ class MainWindow(QtW.QMainWindow):
             aca_attitude = Quat(
                 equatorial=(float(ra / u.deg), float(dec / u.deg), roll)
             )
-            self.plot.set_base_attitude(aca_attitude, update=False)
-            self.plot.set_time(time, update=True)
+            self.plot.set_base_attitude(aca_attitude)
+            self.plot.set_time(time)
 
     def _reset(self):
         self.parameters.set_parameters(**self.opts)
@@ -226,7 +226,7 @@ class MainWindow(QtW.QMainWindow):
         """
         if self._data.proseco:
             self.starcat_view.set_catalog(self._data.proseco["aca"])
-            self.plot.set_catalog(self._data.proseco["catalog"], update=False)
+            self.plot.set_catalog(self._data.proseco["catalog"])
 
     def _export_proseco(self):
         """

--- a/aperoll/widgets/main_window.py
+++ b/aperoll/widgets/main_window.py
@@ -189,7 +189,9 @@ class MainWindow(QtW.QMainWindow):
         event.accept()
 
     def _parameters_changed(self):
-        self._data.reset(self.parameters.proseco_args())
+        proseco_args = self.parameters.proseco_args()
+        self.plot.set_base_attitude(proseco_args["att"])
+        self._data.reset(proseco_args)
 
     def _init(self):
         if self.parameters.values:

--- a/aperoll/widgets/parameters.py
+++ b/aperoll/widgets/parameters.py
@@ -506,6 +506,7 @@ class Parameters(QtW.QWidget):
             "detector": self.values["instrument"],
             "sim_offset": 0,  # docs say this is optional, but it does not seem to be
             "focus_offset": 0,  # docs say this is optional, but it does not seem to be
+            "dyn_bgd_n_faint": 2,
         }
 
         for key in [

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -4,10 +4,8 @@ import tables
 from astropy import units as u
 from astropy.table import Table, vstack
 from chandra_aca.transform import (
-    pixels_to_yagzag,
     radec_to_yagzag,
     yagzag_to_pixels,
-    yagzag_to_radec,
 )
 from cxotime import CxoTime
 from PyQt5 import QtCore as QtC
@@ -15,223 +13,8 @@ from PyQt5 import QtGui as QtG
 from PyQt5 import QtWidgets as QtW
 from Quaternion import Quat
 
-# The nominal origin of the CCD, in pixel coordinates (yagzag_to_pixels(0, 0))
-CCD_ORIGIN = yagzag_to_pixels(
-    0, 0
-)  # (6.08840495576943, 4.92618563916467) as of this writing
-# The (0,0) point of the CCD coordinates in (yag, zag)
-YZ_ORIGIN = pixels_to_yagzag(0, 0)
-
-
-def symsize(mag):
-    # map mags to figsizes, defining
-    # mag 6 as 40 and mag 11 as 3
-    # interp should leave it at the bounding value outside
-    # the range
-    return np.interp(mag, [6.0, 11.0], [32.0, 8.0])
-
-
-class Star(QtW.QGraphicsEllipseItem):
-    def __init__(self, star, parent=None, highlight=False):
-        s = symsize(star["MAG_ACA"])
-        rect = QtC.QRectF(-s / 2, -s / 2, s, s)
-        super().__init__(rect, parent)
-        self.star = star
-        self.highlight = highlight
-        color = self.color()
-        self.setBrush(QtG.QBrush(color))
-        self.setPen(QtG.QPen(color))
-        self.included = {
-            "acq": None,
-            "guide": None,
-        }
-        # stars are stacked in z by magnitude, so small stars never hide behind big ones
-        # the brightest entry in the catalog has MAG_ACA = -1.801
-        # the faintest entry in the catalog has MAG_ACA ~ 21.5
-        self.setZValue(20 + star["MAG_ACA"])
-
-    def __repr__(self):
-        return f"Star({self.star['AGASC_ID']})"
-
-    def color(self):
-        if self.highlight:
-            return QtG.QColor("red")
-        if self.star["MAG_ACA"] > 10.5:
-            return QtG.QColor("lightGray")
-        if self.bad():
-            return QtG.QColor(255, 99, 71, 191)
-        return QtG.QColor("black")
-
-    def bad(self):
-        ok = (
-            (self.star["CLASS"] == 0)
-            & (self.star["MAG_ACA"] > 5.3)
-            & (self.star["MAG_ACA"] < 11.0)
-            & (~np.isclose(self.star["COLOR1"], 0.7))
-            & (self.star["MAG_ACA_ERR"] < 100.0)  # mag_err is in 0.01 mag
-            & (self.star["ASPQ1"] < 40)
-            & (  # Less than 2 arcsec centroid offset due to nearby spoiler
-                self.star["ASPQ2"] == 0
-            )
-            & (self.star["POS_ERR"] < 3000)  # Position error < 3.0 arcsec
-            & (
-                (self.star["VAR"] == -9999) | (self.star["VAR"] == 5)
-            )  # Not known to vary > 0.2 mag
-        )
-        return not ok
-
-    def text(self):
-        return (
-            "<pre>"
-            f"ID:      {self.star['AGASC_ID']}\n"
-            f"mag:     {self.star['MAG_ACA']:.2f} +- {self.star['MAG_ACA_ERR']/100:.2}\n"
-            f"color:   {self.star['COLOR1']:.2f}\n"
-            f"ASPQ1:   {self.star['ASPQ1']}\n"
-            f"ASPQ2:   {self.star['ASPQ2']}\n"
-            f"class:   {self.star['CLASS']}\n"
-            f"pos err: {self.star['POS_ERR']/1000} mas\n"
-            f"VAR:     {self.star['VAR']}"
-            "</pre>"
-        )
-
-
-class Catalog(QtW.QGraphicsItem):
-    """
-    Utility class to keep together all graphics item for a star catalog.
-
-    Note that the position of the catalog is ALLWAYS (0,0) and the item positions need to be set
-    separately for a given attitude.
-    """
-
-    def __init__(self, catalog, parent=None):
-        super().__init__(parent)
-        self.starcat = catalog.copy()  # will add some columns
-
-        cat = Table(self.starcat)
-        # item positions are set from row/col
-        cat["row"], cat["col"] = yagzag_to_pixels(
-            cat["yang"], cat["zang"], allow_bad=True
-        )
-        # when attitude changes, the positions (row, col) are recalculated from (ra, dec)
-        # so these items move with the corresponding star.
-        cat["ra"], cat["dec"] = yagzag_to_radec(
-            cat["yang"], cat["zang"], self.starcat.att
-        )
-        gui_stars = cat[(cat["type"] == "GUI") | (cat["type"] == "BOT")]
-        acq_stars = cat[(cat["type"] == "ACQ") | (cat["type"] == "BOT")]
-        fids = cat[cat["type"] == "FID"]
-        mon_wins = cat[cat["type"] == "MON"]
-
-        self.star_labels = [StarcatLabel(star, self) for star in cat]
-        self.guide_stars = [GuideStar(gui_star, self) for gui_star in gui_stars]
-        self.acq_stars = [AcqStar(acq_star, self) for acq_star in acq_stars]
-        self.mon_stars = [MonBox(mon_box, self) for mon_box in mon_wins]
-        self.fid_lights = [FidLight(fid, self) for fid in fids]
-
-    def setPos(self, *_args, **_kwargs):
-        # the position of the catalog is ALLWAYS (0,0)
-        pass
-
-    def set_pos_for_attitude(self, attitude):
-        """
-        Set the position of all items in the catalog for a given attitude.
-
-        Calling QGraphicsItem.set_pos would not work. Children positions are relative to the
-        parent, but in reality the relative distances between items changes with the attitude.
-        One cannot change the position of a single item and then get the rest as a relative shift.
-        Each item needs to be set individually.
-        """
-        # item positions are relative to the parent's position (self)
-        # but the parent's position is (or should be) always (0, 0)
-        for item in self.childItems():
-            yag, zag = radec_to_yagzag(
-                item.starcat_row["ra"], item.starcat_row["dec"], attitude
-            )
-            row, col = yagzag_to_pixels(
-                yag, zag, allow_bad=True
-            )
-            # item.setPos(-yag, -zag)
-            item.setPos(row, -col)
-
-    def boundingRect(self):
-        return QtC.QRectF(0, 0, 1, 1)
-
-    def paint(self, _painter, _option, _widget):
-        # this item draws nothing, it just holds children
-        pass
-
-    def __repr__(self):
-        return repr(self.starcat)
-
-
-class FidLight(QtW.QGraphicsEllipseItem):
-    def __init__(self, fid, parent=None):
-        self.starcat_row = fid
-        s = 27
-        w = 3
-        rect = QtC.QRectF(-s, -s, 2 * s, 2 * s)
-        super().__init__(rect, parent)
-        self.fid = fid
-        pen = QtG.QPen(QtG.QColor("red"), w)
-        self.setPen(pen)
-        # self.setPos(-fid["yang"], -fid["zang"])
-        self.setPos(fid["row"], -fid["col"])
-
-        line = QtW.QGraphicsLineItem(-s, 0, s, 0, self)
-        line.setPen(pen)
-        line = QtW.QGraphicsLineItem(0, -s, 0, s, self)
-        line.setPen(pen)
-
-
-class StarcatLabel(QtW.QGraphicsTextItem):
-    def __init__(self, star, parent=None):
-        self.starcat_row = star
-        super().__init__(f"{star['idx']}", parent)
-        self._offset = 30
-        self.setFont(QtG.QFont("Arial", 30))
-        self.setDefaultTextColor(QtG.QColor("red"))
-        # self.setPos(-star["yang"], -star["zang"])
-        self.setPos(star["row"], -star["col"])
-
-    def setPos(self, x, y):
-        rect = self.boundingRect()
-        super().setPos(
-            x + self._offset - rect.width() / 2, y - self._offset - rect.height() / 2
-        )
-
-
-class GuideStar(QtW.QGraphicsEllipseItem):
-    def __init__(self, star, parent=None):
-        self.starcat_row = star
-        s = 27
-        w = 5
-        rect = QtC.QRectF(-s, -s, s * 2, s * 2)
-        super().__init__(rect, parent)
-        self.setPen(QtG.QPen(QtG.QColor("green"), w))
-        # self.setPos(-star["yang"], -star["zang"])
-        self.setPos(star["row"], -star["col"])
-
-
-class AcqStar(QtW.QGraphicsRectItem):
-    def __init__(self, star, parent=None):
-        self.starcat_row = star
-        hw = star["halfw"] / 5
-        w = 5
-        super().__init__(-hw, -hw, hw * 2, hw * 2, parent)
-        self.setPen(QtG.QPen(QtG.QColor("blue"), w))
-        # self.setPos(-star["yang"], -star["zang"])
-        self.setPos(star["row"], -star["col"])
-
-
-class MonBox(QtW.QGraphicsRectItem):
-    def __init__(self, star, parent=None):
-        self.starcat_row = star
-        # starcheck convention was to plot monitor boxes at 2X halfw
-        hw = star["halfw"] / 5
-        w = 5
-        super().__init__(-(hw * 2), -(hw * 2), hw * 4, hw * 4, parent)
-        self.setPen(QtG.QPen(QtG.QColor(255, 165, 0), w))
-        self.setPos(star["row"], -star["col"])
+from aperoll import utils
+from aperoll.star_field_items import Catalog, Star
 
 
 class StarView(QtW.QGraphicsView):
@@ -337,7 +120,7 @@ class StarView(QtW.QGraphicsView):
         center = self.mapToScene(center)
 
         # The following draws the edges of the CCD
-        frame = _get_camera_fov_frame()
+        frame = utils.get_camera_fov_frame()
 
         row, col = "row", "col"
         painter.setPen(black_pen)
@@ -565,7 +348,7 @@ class StarField(QtW.QGraphicsScene):
         w = 6
         self.addEllipse(-w/2, -w/2, w, w, QtG.QPen(QtG.QColor("blue")))
         self.addEllipse(
-            CCD_ORIGIN[0] - w/2, -CCD_ORIGIN[1] - w/2, w, w, QtG.QPen(QtG.QColor("red"))
+            utils.CCD_ORIGIN[0] - w/2, -utils.CCD_ORIGIN[1] - w/2, w, w, QtG.QPen(QtG.QColor("red"))
         )
 
     def shift_scene(self, dx, dy):
@@ -708,56 +491,6 @@ class StarPlot(QtW.QWidget):
     def show_catalog(self):
         if self._catalog is not None:
             self.scene.add_catalog(self._catalog)
-
-
-def _get_camera_fov_frame():
-    """
-    Paths that correspond ot the edges of the ACA CCD and the quadrant boundaries.
-    """
-    frame = {}
-    N = 100
-    edge_1 = np.array(
-        [[-520, i] for i in np.linspace(-512, 512, N)]
-        + [[i, 512] for i in np.linspace(-520, 520, N)]
-        + [[520, i] for i in np.linspace(512, -512, N)]
-        + [[i, -512] for i in np.linspace(520, -520, N)]
-        + [[-520, 0]]
-    ).T
-    frame["edge_1"] = {
-        "row": edge_1[0],
-        "col": edge_1[1],
-    }
-
-    edge_2 = np.array(
-        [[-512, i] for i in np.linspace(-512, 512, N)]
-        + [[i, 512] for i in np.linspace(-512, 512, N)]
-        + [[512, i] for i in np.linspace(512, -512, N)]
-        + [[i, -512] for i in np.linspace(512, -512, N)]
-        + [[-512, 0]]
-    ).T
-    frame["edge_2"] = {
-        "row": edge_2[0],
-        "col": edge_2[1],
-    }
-
-    cross_2 = np.array([[i, 0] for i in np.linspace(-511, 511, N)]).T
-    frame["cross_2"] = {
-        "row": cross_2[0],
-        "col": cross_2[1],
-    }
-
-    cross_1 = np.array([[0, i] for i in np.linspace(-511, 511, N)]).T
-    frame["cross_1"] = {
-        "row": cross_1[0],
-        "col": cross_1[1],
-    }
-
-    for key in frame:
-        frame[key]["yag"], frame[key]["zag"] = pixels_to_yagzag(
-            frame[key]["row"], frame[key]["col"], allow_bad=True
-        )
-
-    return frame
 
 
 def main():

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -51,8 +51,8 @@ class Star(QtW.QGraphicsEllipseItem):
             "guide": None,
         }
         # stars are stacked in z by magnitude, so small stars never hide behind big ones
-        # the brightest entry in the catalog is has MAG_ACA = -1.801
-        # the faintest entry in the catalog is has MAG_ACA ~ 21.5
+        # the brightest entry in the catalog has MAG_ACA = -1.801
+        # the faintest entry in the catalog has MAG_ACA ~ 21.5
         self.setZValue(20 + star["MAG_ACA"])
 
     def __repr__(self):

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -346,9 +346,13 @@ class StarField(QtW.QGraphicsScene):
         # this draws two circles, a blue one at (0, 0) and a red one at the CCD origin,
         # which corresponds to the ACA pointing. This is useful for debugging.
         w = 6
-        self.addEllipse(-w/2, -w/2, w, w, QtG.QPen(QtG.QColor("blue")))
+        self.addEllipse(-w / 2, -w / 2, w, w, QtG.QPen(QtG.QColor("blue")))
         self.addEllipse(
-            utils.CCD_ORIGIN[0] - w/2, -utils.CCD_ORIGIN[1] - w/2, w, w, QtG.QPen(QtG.QColor("red"))
+            utils.CCD_ORIGIN[0] - w / 2,
+            -utils.CCD_ORIGIN[1] - w / 2,
+            w,
+            w,
+            QtG.QPen(QtG.QColor("red")),
         )
 
     def shift_scene(self, dx, dy):

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -1,3 +1,4 @@
+import agasc
 import numpy as np
 from astropy.table import Table
 from chandra_aca.transform import (
@@ -27,28 +28,22 @@ def symsize(mag):
 
 
 def get_stars(starcat_time, quaternion, radius=2):
-    import agasc
-    from Ska.quatutil import radec2yagzag
-
     stars = agasc.get_agasc_cone(
         quaternion.ra, quaternion.dec, radius=radius, date=starcat_time
     )
 
     if "yang" not in stars.colnames or "zang" not in stars.colnames:
-        # Add star Y angle and Z angle in arcsec to the stars table.
-        # radec2yagzag returns degrees.
-        yags, zags = radec2yagzag(stars["RA_PMCORR"], stars["DEC_PMCORR"], quaternion)
-        stars["yang"] = yags * 3600
-        stars["zang"] = zags * 3600
+        stars["yang"], stars["zang"] = radec_to_yagzag(
+            stars["RA_PMCORR"], stars["DEC_PMCORR"], quaternion
+        )
 
     return stars
 
 
 class Star(QtW.QGraphicsEllipseItem):
     def __init__(self, star, parent=None, highlight=False):
-        s = symsize(star["MAG_ACA"])
-        # note that the coordinate system is (row, -col)
-        rect = QtC.QRectF(star["row"] - s / 2, -star["col"] - s / 2, s, s)
+        s = symsize(star["MAG_ACA"]) * 10
+        rect = QtC.QRectF(-s / 2, -s / 2, s, s)
         super().__init__(rect, parent)
         self.star = star
         self.highlight = highlight
@@ -59,6 +54,10 @@ class Star(QtW.QGraphicsEllipseItem):
             "acq": None,
             "guide": None,
         }
+        # stars are stacked in z by magnitude, so small stars never hide behind big ones
+        # the brightest entry in the catalog is has MAG_ACA = -1.801
+        # the faintest entry in the catalog is has MAG_ACA ~ 21.5
+        self.setZValue(20 + star["MAG_ACA"])
 
     def __repr__(self):
         return f"Star({self.star['AGASC_ID']})"
@@ -105,14 +104,146 @@ class Star(QtW.QGraphicsEllipseItem):
         )
 
 
+class Catalog(QtW.QGraphicsItem):
+    """
+    Utility class to keep together all graphics item for a star catalog.
+
+    Note that the position of the catalog is ALLWAYS (0,0) and the item positions need to be set
+    separately for a given attitude.
+    """
+
+    def __init__(self, catalog, parent=None):
+        super().__init__(parent)
+        self.starcat = catalog.copy()  # will add some columns
+
+        cat = Table(self.starcat)
+        cat["row"], cat["col"] = yagzag_to_pixels(
+            cat["yang"], cat["zang"], allow_bad=True
+        )
+        cat["ra"], cat["dec"] = yagzag_to_radec(
+            cat["yang"], cat["zang"], self.starcat.att
+        )
+        cat["angle_halfw"] = cat["halfw"]
+        gui_stars = cat[(cat["type"] == "GUI") | (cat["type"] == "BOT")]
+        acq_stars = cat[(cat["type"] == "ACQ") | (cat["type"] == "BOT")]
+        fids = cat[cat["type"] == "FID"]
+        mon_wins = cat[cat["type"] == "MON"]
+
+        self.star_labels = [StarcatLabel(star, self) for star in cat]
+        self.guide_stars = [GuideStar(gui_star, self) for gui_star in gui_stars]
+        self.acq_stars = [AcqStar(acq_star, self) for acq_star in acq_stars]
+        self.mon_stars = [MonBox(mon_box, self) for mon_box in mon_wins]
+        self.fid_lights = [FidLight(fid, self) for fid in fids]
+
+    def setPos(self, *_args, **_kwargs):
+        # the position of the catalog is ALLWAYS (0,0)
+        pass
+
+    def set_pos_for_attitude(self, attitude):
+        """
+        Set the position of all items in the catalog for a given attitude.
+
+        Calling QGraphicsItem.set_pos would not work. Children positions are relative to the
+        parent, but in reality the relative distances between items changes with the attitude.
+        One cannot change the position of a single item and then get the rest as a relative shift.
+        Each item needs to be set individually.
+        """
+        # item positions are relative to the parent's position (self)
+        # but the parent's position is (or should be) always (0, 0)
+        for item in self.childItems():
+            yag, zag = radec_to_yagzag(
+                item.starcat_row["ra"], item.starcat_row["dec"], attitude
+            )
+            item.setPos(-yag, -zag)
+
+    def boundingRect(self):
+        return QtC.QRectF(0, 0, 1, 1)
+
+    def paint(self, _painter, _option, _widget):
+        # this item draws nothing, it just holds children
+        pass
+
+    def __repr__(self):
+        return repr(self.starcat)
+
+
+class FidLight(QtW.QGraphicsEllipseItem):
+    def __init__(self, fid, parent=None):
+        self.starcat_row = fid
+        s = 25
+        w = 3
+        s *= 5
+        w *= 5
+        rect = QtC.QRectF(-s, -s, 2 * s, 2 * s)
+        super().__init__(rect, parent)
+        self.fid = fid
+        pen = QtG.QPen(QtG.QColor("red"), w)
+        self.setPen(pen)
+        self.setPos(-fid["yang"], -fid["zang"])
+
+        line = QtW.QGraphicsLineItem(-s, 0, s, 0, self)
+        line.setPen(pen)
+        line = QtW.QGraphicsLineItem(0, -s, 0, s, self)
+        line.setPen(pen)
+
+
+class StarcatLabel(QtW.QGraphicsTextItem):
+    def __init__(self, star, parent=None):
+        self.starcat_row = star
+        super().__init__(f"{star['idx']}", parent)
+        self._offset = 150
+        self.setFont(QtG.QFont("Arial", 150))
+        self.setDefaultTextColor(QtG.QColor("red"))
+        self.setPos(-star["yang"], -star["zang"])
+
+    def setPos(self, x, y):
+        rect = self.boundingRect()
+        super().setPos(
+            x + self._offset - rect.width() / 2, y - self._offset - rect.height() / 2
+        )
+
+
+class GuideStar(QtW.QGraphicsEllipseItem):
+    def __init__(self, star, parent=None):
+        self.starcat_row = star
+        s = 90
+        w = 15
+        rect = QtC.QRectF(-s, -s, s * 2, s * 2)
+        super().__init__(rect, parent)
+        self.setPen(QtG.QPen(QtG.QColor("green"), w))
+        self.setPos(-star["yang"], -star["zang"])
+
+
+class AcqStar(QtW.QGraphicsRectItem):
+    def __init__(self, star, parent=None):
+        self.starcat_row = star
+        hw = star["angle_halfw"]
+        w = 15
+        super().__init__(-hw, -hw, hw * 2, hw * 2, parent)
+        self.setPen(QtG.QPen(QtG.QColor("blue"), w))
+        self.setPos(-star["yang"], -star["zang"])
+
+
+class MonBox(QtW.QGraphicsRectItem):
+    def __init__(self, star, parent=None):
+        self.starcat_row = star
+        # starcheck convention was to plot monitor boxes at 2X halfw
+        hw = star["angle_halfw"]
+        w = 15
+        super().__init__(-(hw * 2), -(hw * 2), hw * 4, hw * 4, parent)
+        self.setPen(QtG.QPen(QtG.QColor(255, 165, 0), w))
+        self.setPos(-star["yang"], -star["zang"])
+
+
 class StarView(QtW.QGraphicsView):
-    roll_changed = QtC.pyqtSignal(float)
     include_star = QtC.pyqtSignal(int, str, object)
 
     def __init__(self, scene=None):
         super().__init__(scene)
         # mouseTracking is set so we can show tooltips
         self.setMouseTracking(True)
+        # Antialiasing could be disabled if it affects performance
+        self.setRenderHint(QtG.QPainter.Antialiasing)
 
         self._start = None
         self._rotating = False
@@ -143,15 +274,7 @@ class StarView(QtW.QGraphicsView):
             start_pos = self.mapToScene(self._start)
             if self._moving:
                 dx, dy = end_pos.x() - start_pos.x(), end_pos.y() - start_pos.y()
-
-                scene_rect = self.scene().sceneRect()
-                new_scene_rect = QtC.QRectF(
-                    scene_rect.x() - dx,
-                    scene_rect.y() - dy,
-                    scene_rect.width(),
-                    scene_rect.height(),
-                )
-                self.scene().setSceneRect(new_scene_rect)
+                self.scene().shift_scene(dx, dy)
             elif self._rotating:
                 center = self.mapToScene(self.viewport().rect().center())
                 x1 = start_pos.x() - center.x()
@@ -161,9 +284,7 @@ class StarView(QtW.QGraphicsView):
                 r1 = np.sqrt(x1**2 + y1**2)
                 r2 = np.sqrt(x2**2 + y2**2)
                 angle = np.rad2deg(np.arcsin((x1 * y2 - x2 * y1) / (r1 * r2)))
-                transform = self.viewportTransform().rotate(angle)
-                self.setTransform(transform)
-                self.roll_changed.emit(self.get_roll_offset())
+                self.scene().rotate_scene(angle, center)
 
             self._start = pos
 
@@ -181,139 +302,47 @@ class StarView(QtW.QGraphicsView):
         scale = 1 + 0.5 * event.angleDelta().y() / 360
         self.scale(scale, scale)
 
-    def drawForeground(self, painter, rect):
+    def drawForeground(self, painter, _rect):
+        # I want to use antialising for these lines regardless of what is set for the scene,
+        # because they are large and otherwise look hideous. It will be reset at the end.
+        anti_aliasing_set = painter.testRenderHint(QtG.QPainter.Antialiasing)
+        painter.setRenderHint(QtG.QPainter.Antialiasing, True)
+
         black_pen = QtG.QPen()
-        black_pen.setWidth(2)
+        black_pen.setWidth(10)
         center = QtC.QPoint(self.viewport().width() // 2, self.viewport().height() // 2)
         center = self.mapToScene(center)
-
-        # this rectangle is adapted to the "current" field of view
-        # and it moves together with the stars in the scene
-        # b1hw = 512
-        # painter.drawRect(-b1hw, -b1hw, 2 * b1hw, 2 * b1hw)
-
-        # these was to fix the frame to the view by rotating the viewport
-        # everything drawn after this will not rotate when the canvas is rotated
-        # I don't remember why it was needed. Leaving it here for now.
-        # since then, I chenged the transforms
-        # transform = self.viewportTransform()
-        # t11 = transform.m11()
-        # t12 = transform.m12()
-        # angle = np.rad2deg(np.arctan2(t12, t11))
-        # painter.translate(center)
-        # painter.rotate(-angle)
-        # painter.translate(-center)
 
         # The following draws the edges of the CCD
-        att_offset = self.get_attitude_offset(no_roll=True).inv()
+        frame = _get_camera_fov_frame()
 
+        row, col = "yag", "zag"
         painter.setPen(black_pen)
-        N = 100
-        edge_1 = np.array(
-            [[-520, i] for i in np.linspace(-512, 512, N)]
-            + [[i, 512] for i in np.linspace(-520, 520, N)]
-            + [[520, i] for i in np.linspace(512, -512, N)]
-            + [[i, -512] for i in np.linspace(520, -520, N)]
-            + [[-520, 0]]
-        ).T
-        row2, col2 = self.transform_pixels_to_attitude(edge_1[0], edge_1[1], att_offset)
-        for i in range(len(row2) - 1):
+        for i in range(len(frame["edge_1"][row]) - 1):
             painter.drawLine(
-                QtC.QPointF(row2[i], col2[i]), QtC.QPointF(row2[i + 1], col2[i + 1])
+                QtC.QPointF(frame["edge_1"][row][i], frame["edge_1"][col][i]),
+                QtC.QPointF(frame["edge_1"][row][i + 1], frame["edge_1"][col][i + 1]),
+            )
+        for i in range(len(frame["edge_2"][row]) - 1):
+            painter.drawLine(
+                QtC.QPointF(frame["edge_2"][row][i], frame["edge_2"][col][i]),
+                QtC.QPointF(frame["edge_2"][row][i + 1], frame["edge_2"][col][i + 1]),
             )
 
-        edge_2 = np.array(
-            [[-512, i] for i in np.linspace(-512, 512, N)]
-            + [[i, 512] for i in np.linspace(-512, 512, N)]
-            + [[512, i] for i in np.linspace(512, -512, N)]
-            + [[i, -512] for i in np.linspace(512, -512, N)]
-            + [[-512, 0]]
-        ).T
-        row2, col2 = self.transform_pixels_to_attitude(edge_2[0], edge_2[1], att_offset)
-        for i in range(len(row2) - 1):
+        magenta_pen = QtG.QPen(QtG.QColor("magenta"))
+        magenta_pen.setWidth(10)
+        painter.setPen(magenta_pen)
+        for i in range(len(frame["cross_2"][row]) - 1):
             painter.drawLine(
-                QtC.QPointF(row2[i], col2[i]), QtC.QPointF(row2[i + 1], col2[i + 1])
+                QtC.QPointF(frame["cross_2"][row][i], frame["cross_2"][col][i]),
+                QtC.QPointF(frame["cross_2"][row][i + 1], frame["cross_2"][col][i + 1]),
             )
-
-        painter.setPen(QtG.QPen(QtG.QColor("magenta")))
-        cross_2 = np.array([[i, 0] for i in np.linspace(-511, 511, N)]).T
-        row2, col2 = self.transform_pixels_to_attitude(
-            cross_2[0], cross_2[1], att_offset
-        )
-        for i in range(len(row2) - 1):
+        for i in range(len(frame["cross_1"][row]) - 1):
             painter.drawLine(
-                QtC.QPointF(row2[i], col2[i]), QtC.QPointF(row2[i + 1], col2[i + 1])
+                QtC.QPointF(frame["cross_1"][row][i], frame["cross_1"][col][i]),
+                QtC.QPointF(frame["cross_1"][row][i + 1], frame["cross_1"][col][i + 1]),
             )
-
-        cross_1 = np.array([[0, i] for i in np.linspace(-511, 511, N)]).T
-        row2, col2 = self.transform_pixels_to_attitude(
-            cross_1[0], cross_1[1], att_offset
-        )
-        for i in range(len(row2) - 1):
-            painter.drawLine(
-                QtC.QPointF(row2[i], col2[i]), QtC.QPointF(row2[i + 1], col2[i + 1])
-            )
-
-    def transform_pixels_to_attitude(self, row, col, q):
-        row, col = self.transform_pixels_to_attitude_2(row, col, q)
-        row, col = self.transform_pixels_to_attitude_1(row, col, q)
-        return row, col
-
-    def transform_pixels_to_attitude_1(self, row, col, q):
-        q0 = Quat(q=[0, 0, 0, 1])
-        y, z = pixels_to_yagzag(row, col, allow_bad=True)
-        ra, dec = yagzag_to_radec(y, z, q0)
-        y2, z2 = radec_to_yagzag(ra, dec, q)
-        row, col = yagzag_to_pixels(y2, z2, allow_bad=True)
-        return row, col
-
-    def transform_pixels_to_attitude_2(self, row, col, q):
-        transform = self.viewportTransform()
-        row_col = np.array([row, col])
-        transform = np.array(
-            [[transform.m11(), transform.m12()], [transform.m21(), transform.m22()]]
-        )
-        # all scaling transforms we apply are isotropic, therefore the two eigenvalues are equal,
-        # so the following turns the transform into a rotation matrix
-        transform /= np.sqrt(np.linalg.det(transform))
-        # the following is a sanity check (that it is actually a rotation)
-        assert np.allclose(transform[0, 1], -transform[1, 0])
-        assert np.allclose(np.linalg.det(transform), 1)
-        row, col = transform @ row_col
-        return row, col
-
-    def get_origin_offset(self):
-        """
-        Get the translation offset (in pixels) of the current view from (511, 511)
-        """
-        center = QtC.QPoint(self.viewport().width() // 2, self.viewport().height() // 2)
-        center = self.mapToScene(center)
-        return center.x(), center.y()
-
-    def get_roll_offset(self):
-        transform = self.viewportTransform()
-        return np.rad2deg(np.arctan2(transform.m12(), transform.m11()))
-
-    def get_attitude_offset(self, no_roll=False):
-        x, y = self.get_origin_offset()
-        yag, zag = pixels_to_yagzag(
-            CCD_ORIGIN[0] + x, CCD_ORIGIN[1] - y, allow_bad=True
-        )
-        if no_roll:
-            roll = 0
-        else:
-            roll = self.get_roll_offset()
-        q = Quat(equatorial=[yag / 3600, -zag / 3600, roll])
-        return q
-
-    def re_center(self):
-        scene_rect = self.scene().sceneRect()
-        w, h = scene_rect.width(), scene_rect.height()
-        new_scene_rect = QtC.QRectF(-w / 2, -h / 2, w, h)
-        # print(f'recentering {w}, {h}')
-        self.scene().setSceneRect(new_scene_rect)
-        transform = self.viewportTransform().rotate(-self.get_roll_offset())
-        self.setTransform(transform)
+        painter.setRenderHint(QtG.QPainter.Antialiasing, anti_aliasing_set)
 
     def contextMenuEvent(self, event):
         items = [item for item in self.items(event.pos()) if isinstance(item, Star)]
@@ -352,6 +381,80 @@ class StarView(QtW.QGraphicsView):
                 )
         event.accept()
 
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        if event.oldSize().width() == -1 and event.oldSize().height() == -1:
+            # this fits the viewport to a circle of radius 7200 plus some margine
+            # (this assumes the scene is in arcsec, where the diagonal of the CCD is ~7200 arcsec)
+            scale = min(event.size().height(), event.size().width()) / 10000
+            self.scale(scale, scale)
+
+class StarField(QtW.QGraphicsScene):
+    attitude_changed = QtC.pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.attitude = None
+        self.stars = []
+        self._catalog = None
+
+    def add_stars(self, stars):
+        self.stars = stars
+        self.stars["row"], self.stars["col"] = yagzag_to_pixels(
+            self.stars["yang"], self.stars["zang"], allow_bad=True
+        )
+        black_pen = QtG.QPen()
+        black_pen.setWidth(2)
+        self.stars = [Star(star, highlight=False) for star in self.stars]
+        for item in self.stars:
+            # note that the coordinate system is (row, -col), which is (-yag, -zag)
+            yag, zag = radec_to_yagzag(
+                item.star["RA_PMCORR"], item.star["DEC_PMCORR"], self.attitude
+            )
+            item.setPos(-yag, -zag)
+            self.addItem(item)
+
+    def shift_scene(self, dx, dy):
+        """
+        Apply an active transformation on the scene, shifting the items.
+        """
+        if self.attitude is None:
+            return
+        dq = Quat(equatorial=[dx / 3600, dy / 3600, 0])
+        self.set_attitude(self.attitude * dq)
+
+    def rotate_scene(self, angle, around=None):
+        """
+        Apply an active transformation on the scene, rotating the items around the given point.
+        """
+        if self.attitude is None:
+            return
+
+        dq = Quat(equatorial=[0, 0, -angle])
+        self.set_attitude(self.attitude * dq)
+
+    def set_attitude(self, q):
+        """
+        Set the attitude of the scene, rotating the items to the given attitude.
+        """
+        self.attitude = q
+        for item in self.stars:
+            yag, zag = radec_to_yagzag(
+                item.star["RA_PMCORR"], item.star["DEC_PMCORR"], self.attitude
+            )
+            item.setPos(-yag, -zag)
+
+        if self._catalog is not None:
+            self._catalog.set_pos_for_attitude(self.attitude)
+        self.attitude_changed.emit()
+
+    def add_catalog(self, starcat):
+        if self._catalog is not None:
+            self.removeItem(self._catalog)
+
+        self._catalog = Catalog(starcat)
+        self.addItem(self._catalog)
 
 class StarPlot(QtW.QWidget):
     attitude_changed = QtC.pyqtSignal(float, float, float)
@@ -365,71 +468,29 @@ class StarPlot(QtW.QWidget):
 
         self._origin = [6.08840495576943, 4.92618563916467]
 
-        self.scene = QtW.QGraphicsScene(self)
+        self.scene = StarField(self)
         self.scene.setSceneRect(-100, -100, 200, 200)
 
         self.view = StarView(self.scene)
-        scale = 1
-        self.view.scale(scale, scale)  # I should not need this but...
 
         self.layout().addWidget(self.view)
 
         self.stars = None
-        # "base attitude" refers to the attitude when the viewport is at the origin and not rotated
-        # the actual attitude takes the base attitude and applies a displacement and a rotation
-        self._base_attitude = None
-        # "current attitude" refers to the attitude taking into account the viewport's position
-        self._current_attitude = None
         self._time = None
         self._highlight = []
         self._catalog = None
 
-        self._catalog_items = []
-        self._test_stars_items = []
-
-        self.scene.sceneRectChanged.connect(self._radec_changed)
-        self.view.roll_changed.connect(self._roll_changed)
+        self.scene.attitude_changed.connect(self._attitude_changed)
 
         self.view.include_star.connect(self.include_star)
 
-    def _radec_changed(self):
-        # RA/dec change when the scene rectangle changes, and its given by the rectangle's center
-        # the base attitude corresponds to RA/dec at the origin, se we take the displacement
-        # of the view offset, apply it from the origin, and get ra/dec for the offset origin
-        if self._base_attitude is None:
-            return
-        x, y = self.view.get_origin_offset()
-        yag, zag = pixels_to_yagzag(
-            self._origin[0] + x, self._origin[1] - y, allow_bad=True
-        )
-        ra, dec = yagzag_to_radec(yag, zag, self._base_attitude)
-        # print('RA/dec changed', ra, dec)
-        self._current_attitude = Quat(equatorial=[ra, dec, self._current_attitude.roll])
-        # print(f'Attitude changed. RA: {ra}, dec: {dec}, roll: {roll} ({x}, {y})')
-        self.attitude_changed.emit(
-            self._current_attitude.ra,
-            self._current_attitude.dec,
-            self._current_attitude.roll,
-        )
-
-    def _roll_changed(self, roll_offset):
-        if self._current_attitude is None:
-            return
-        # roll changes when the viewport is rotated.
-        # the view class keeps track of this.
-        # print('roll changed', roll_offset)
-        self._current_attitude = Quat(
-            equatorial=[
-                self._current_attitude.ra,
-                self._current_attitude.dec,
-                self._base_attitude.roll - roll_offset,
-            ]
-        )
-        self.attitude_changed.emit(
-            self._current_attitude.ra,
-            self._current_attitude.dec,
-            self._current_attitude.roll,
-        )
+    def _attitude_changed(self):
+        if self.scene.attitude is not None:
+            self.attitude_changed.emit(
+                self.scene.attitude.ra,
+                self.scene.attitude.dec,
+                self.scene.attitude.roll,
+            )
 
     def set_base_attitude(self, q, update=True):
         """
@@ -440,8 +501,7 @@ class StarPlot(QtW.QWidget):
         leave the display in an inconsistent state. The "update" argument is there as a convenience
         to delay the update in case one wants to call several setters.
         """
-        self._base_attitude = Quat(q)
-        self._current_attitude = Quat(self._base_attitude)
+        self.scene.set_attitude(q)
         if update:
             self.show_stars()
 
@@ -462,150 +522,66 @@ class StarPlot(QtW.QWidget):
         if update:
             self.show_stars()
 
-    def clear_test_stars(self):
-        for item in self._test_stars_items:
-            self.scene.removeItem(item)
-        self._test_stars_items = []
-
-    def show_test_stars(
-        self, ra_offset=0 / 3600, dec_offset=3000 / 3600, roll_offset=15, N=100, mag=10
-    ):
-        dq = Quat(equatorial=[ra_offset, dec_offset, roll_offset])
-        q = self._base_attitude * dq
-        self.show_test_stars_q(q, N, mag)
-
-    def show_test_stars_q(self, q, N=100, mag=10):
-        self.clear_test_stars()
-        if self._base_attitude is None or self._time is None:
-            return
-        red_pen = QtG.QPen(QtG.QColor("red"))
-        red_brush = QtG.QBrush(QtG.QColor("red"))
-
-        # The test stars will be placed so they appar at the edge of the camera
-        # if the attitude is the one given.
-        # These are the positions at the edge, in pixel coordinates
-        rows, cols = np.array(
-            [[-511, i] for i in np.linspace(-511, 511, N)]
-            + [[i, 511] for i in np.linspace(-511, 511, N)]
-            + [[511, i] for i in np.linspace(511, -511, N)]
-            + [[i, -511] for i in np.linspace(511, -511, N)]
-        ).T
-        yags, zags = pixels_to_yagzag(rows, cols, allow_bad=True)
-        # and these are the positions in RA/dec, assuming the given attitude
-        ra, dec = yagzag_to_radec(yags, zags, q)
-        # now transform the other way, assuming the current attitude
-        yags2, zags2 = radec_to_yagzag(ra, dec, self._base_attitude)
-        rows2, cols2 = yagzag_to_pixels(yags2, zags2, allow_bad=True)
-        # and plot them
-        # note that the coordinate system is (row, -col)
-        for row, col in zip(rows2, cols2, strict=False):
-            s = symsize(mag)
-            rect = QtC.QRectF(row - s / 2, -col - s / 2, s, s)
-            self._test_stars_items.append(
-                self.scene.addEllipse(rect, red_pen, red_brush)
-            )
-
     def show_stars(self):
         self.scene.clear()
-        self._catalog_items = []
-        if self._base_attitude is None or self._time is None:
+        if self.scene.attitude is None or self._time is None:
             return
-        self.stars = get_stars(self._time, self._base_attitude)
-        # Update table to include row/col values corresponding to yag/zag
-        self.stars["row"], self.stars["col"] = yagzag_to_pixels(
-            self.stars["yang"], self.stars["zang"], allow_bad=True
-        )
-        black_pen = QtG.QPen()
-        black_pen.setWidth(2)
-        for star in self.stars:
-            self.scene.addItem(
-                Star(star, highlight=star["AGASC_ID"] in self._highlight)
-            )
-
-        # self.view.centerOn(QtC.QPointF(self._origin[0], self._origin[1]))
-        self.view.re_center()
-
-    def clear_catalog(self):
-        for item in self._catalog_items:
-            self.scene.removeItem(item)
-        self._catalog_items = []
+        self.stars = get_stars(self._time, self.scene.attitude)
+        self.scene.add_stars(self.stars)
 
     def show_catalog(self):
-        self.clear_catalog()
         if self._catalog is not None:
-            cat = Table(self._catalog)
-            # the catalog was made using self._current_attitude, but the stars are plotted using
-            # self._base_attitude
-            ra, dec = yagzag_to_radec(cat["yang"], cat["zang"], self._current_attitude)
-            yag, zag = radec_to_yagzag(ra, dec, self._base_attitude)
-            cat["row"], cat["col"] = yagzag_to_pixels(yag, zag, allow_bad=True)
-            gui_stars = cat[(cat["type"] == "GUI") | (cat["type"] == "BOT")]
-            acq_stars = cat[(cat["type"] == "ACQ") | (cat["type"] == "BOT")]
-            fids = cat[cat["type"] == "FID"]
-            mon_wins = cat[cat["type"] == "MON"]
+            self.scene.add_catalog(self._catalog)
 
-            for star in cat:
-                txt = self.scene.addText(
-                    f"{star['idx']}",
-                    QtG.QFont("Arial", 32),
-                )
-                txt.setPos(star["row"] + 16, -star["col"] - 40)
-                txt.setDefaultTextColor(QtG.QColor("red"))
-                self._catalog_items.append(txt)
-            for gui_star in gui_stars:
-                w = 20
-                # note that the coordinate system is (row, -col)
-                rect = QtC.QRectF(
-                    gui_star["row"] - w, -gui_star["col"] - w, w * 2, w * 2
-                )
-                self._catalog_items.append(
-                    self.scene.addEllipse(rect, QtG.QPen(QtG.QColor("green"), 3))
-                )
-            for acq_star in acq_stars:
-                self._catalog_items.append(
-                    self.scene.addRect(
-                        acq_star["row"] - acq_star["halfw"] / 5,
-                        -acq_star["col"] - acq_star["halfw"] / 5,
-                        acq_star["halfw"] * 2 / 5,
-                        acq_star["halfw"] * 2 / 5,
-                        QtG.QPen(QtG.QColor("blue"), 3),
-                    )
-                )
-            for mon_box in mon_wins:
-                # starcheck convention was to plot monitor boxes at 2X halfw
-                self._catalog_items.append(
-                    self.scene.addRect(
-                        mon_box["row"] - (mon_box["halfw"] * 2 / 5),
-                        -mon_box["col"] - (mon_box["halfw"] * 2 / 5),
-                        mon_box["halfw"] * 4 / 5,
-                        mon_box["halfw"] * 4 / 5,
-                        QtG.QPen(QtG.QColor(255, 165, 0), 3),
-                    )
-                )
-            for fid in fids:
-                w = 25
-                rect = QtC.QRectF(fid["row"] - w, -fid["col"] - w, w * 2, w * 2)
-                self._catalog_items.append(
-                    self.scene.addEllipse(rect, QtG.QPen(QtG.QColor("red"), 3))
-                )
-                self._catalog_items.append(
-                    self.scene.addLine(
-                        fid["row"] - w,
-                        -fid["col"],
-                        fid["row"] + w,
-                        -fid["col"],
-                        QtG.QPen(QtG.QColor("red"), 3),
-                    )
-                )
-                self._catalog_items.append(
-                    self.scene.addLine(
-                        fid["row"],
-                        -fid["col"] - w,
-                        fid["row"],
-                        -fid["col"] + w,
-                        QtG.QPen(QtG.QColor("red"), 3),
-                    )
-                )
+
+def _get_camera_fov_frame():
+    """
+    Paths that correspond ot the edges of the ACA CCD and the quadrant boundaries.
+    """
+    frame = {}
+    N = 100
+    edge_1 = np.array(
+        [[-520, i] for i in np.linspace(-512, 512, N)]
+        + [[i, 512] for i in np.linspace(-520, 520, N)]
+        + [[520, i] for i in np.linspace(512, -512, N)]
+        + [[i, -512] for i in np.linspace(520, -520, N)]
+        + [[-520, 0]]
+    ).T
+    frame["edge_1"] = {
+        "row": edge_1[0],
+        "col": edge_1[1],
+    }
+
+    edge_2 = np.array(
+        [[-512, i] for i in np.linspace(-512, 512, N)]
+        + [[i, 512] for i in np.linspace(-512, 512, N)]
+        + [[512, i] for i in np.linspace(512, -512, N)]
+        + [[i, -512] for i in np.linspace(512, -512, N)]
+        + [[-512, 0]]
+    ).T
+    frame["edge_2"] = {
+        "row": edge_2[0],
+        "col": edge_2[1],
+    }
+
+    cross_2 = np.array([[i, 0] for i in np.linspace(-511, 511, N)]).T
+    frame["cross_2"] = {
+        "row": cross_2[0],
+        "col": cross_2[1],
+    }
+
+    cross_1 = np.array([[0, i] for i in np.linspace(-511, 511, N)]).T
+    frame["cross_1"] = {
+        "row": cross_1[0],
+        "col": cross_1[1],
+    }
+
+    for key in frame:
+        frame[key]["yag"], frame[key]["zag"] = pixels_to_yagzag(
+            frame[key]["row"], frame[key]["col"], allow_bad=True
+        )
+
+    return frame
 
 
 def main():

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -606,3 +606,21 @@ class StarPlot(QtW.QWidget):
                         QtG.QPen(QtG.QColor("red"), 3),
                     )
                 )
+
+
+def main():
+    from aperoll.widgets.parameters import get_default_parameters
+
+    params = get_default_parameters()
+
+    app = QtW.QApplication([])
+    w = StarPlot()
+    w.set_base_attitude(params["attitude"], update=False)
+    w.set_time(params["date"], update=True)
+    w.resize(1500, 1000)
+    w.show()
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Note: this PR requires sot/agasc/pull/193.

Changed the way graphic items are handled:
- created several graphic item classes.
- Now transformations are _active_ transformations on the scene, instead of transformations on the view. This makes the code much more understandable, IMO. **However, this would make the display slower when there are many stars**, because when one rotates the view, all items positions are changed in the scene.
- To mitigate the performance hit, items are hidden manually from the view, and there is an automatic maximum magnitude applied when there are many stars.
- Stars are automatically added to the display as you pan/zoom around.

This change makes the code much easier to read. It also fixes a few issues:
- Rotating the view meant that the graphic items in a catalog (notably the labels and the square boxes) were rotated in the star plot. With this change, the stars are moved instead, and the boxes keep their orientation.
- Moving the view meant that the view origin might not be the scene origin, which meant there were two attitudes associated with the display (the center of the scene and the center of the view). That complicated the code. Now there is only one.
- If the center of the view was not at the center of the camera, then shapes had to be deformed. Now that is not needed.
- In master, changing the attitude in the text edit widgets does not change the star plot. This PR fixes that (made possible by the other changes)

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Note: this PR requires sot/agasc/pull/193.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I have the following JSON file
```json
[{
    "obsid": 1,
    "target_name": "GRB 240825A",
    "chip_id": 7,
    "chipx": 193.74,
    "chipy": 520.0,
    "dec_targ": 1.026897,
    "detector": "ACIS-S",
    "dither_y": 4,
    "dither_z": 4,
    "focus_offset": 0,
    "man_angle": 5.0,
    "obs_date": "2024:312:00:00:00.000",
    "offset_y": 0.0,
    "offset_z": 0.0,
    "ra_targ": 344.571937,
    "roll_targ": 302.0,
    "sim_offset": 0
}]
```

and I ran
```
aperoll input.json 
```

you can also run
```
python -m aperoll.widgets.star_plot     
```