### PR TITLE
Added new QGRaphicsItems (FieldOfView, Centroid)

### DIFF
--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -453,7 +453,8 @@ class FieldOfView(QtW.QGraphicsItem):
         self.attitude = attitude
         self.centroids = [Centroid(i, parent=self) for i in range(8)]
         self._centroids = np.array(
-            [(0, 511, 511, 511, 511, 14, 0, 0, 0, 0) for _ in self.centroids],
+            # pixels right outside the CCD by default
+            [(0, 511, 511, 511, 511, 14, -2490, 2507, False, False) for _ in self.centroids],
             dtype=[
                 ("IMGNUM", int),
                 ("IMGROW0_8X8", float),

--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -304,7 +304,9 @@ class FieldOfView(QtW.QGraphicsItem):
             return
         self._attitude = attitude
         if self.camera_outline is None:
-            self.camera_outline = CameraOutline(attitude, parent=self, simple=self.alternate_outline)
+            self.camera_outline = CameraOutline(
+                attitude, parent=self, simple=self.alternate_outline
+            )
         else:
             self.camera_outline.attitude = attitude
         if self.scene() is not None and self.scene().attitude is not None:

--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -454,7 +454,10 @@ class FieldOfView(QtW.QGraphicsItem):
         self.centroids = [Centroid(i, parent=self) for i in range(8)]
         self._centroids = np.array(
             # pixels right outside the CCD by default
-            [(0, 511, 511, 511, 511, 14, -2490, 2507, False, False) for _ in self.centroids],
+            [
+                (0, 511, 511, 511, 511, 14, -2490, 2507, False, False)
+                for _ in self.centroids
+            ],
             dtype=[
                 ("IMGNUM", int),
                 ("IMGROW0_8X8", float),

--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -14,6 +14,8 @@ from PyQt5 import QtCore as QtC
 from PyQt5 import QtGui as QtG
 from PyQt5 import QtWidgets as QtW
 
+from aperoll import utils
+
 __all__ = [
     "Star",
     "Catalog",
@@ -22,6 +24,9 @@ __all__ = [
     "GuideStar",
     "AcqStar",
     "MonBox",
+    "Centroid",
+    "CameraOutline",
+    "FieldOfView",
 ]
 
 
@@ -91,8 +96,20 @@ class Catalog(QtW.QGraphicsItem):
     separately for a given attitude.
     """
 
-    def __init__(self, catalog, parent=None):
+    def __init__(self, catalog=None, parent=None):
         super().__init__(parent)
+        self.reset(catalog)
+        self.setZValue(50)
+
+    def reset(self, catalog):
+        self.starcat = None
+        for item in self.childItems():
+            item.setParentItem(None)
+            item.hide()
+
+        if catalog is None:
+            return
+
         self.starcat = catalog.copy()  # will add some columns
 
         cat = Table(self.starcat)
@@ -148,6 +165,39 @@ class Catalog(QtW.QGraphicsItem):
 
     def __repr__(self):
         return repr(self.starcat)
+
+
+class Centroid(QtW.QGraphicsEllipseItem):
+    def __init__(self, imgnum, parent=None):
+        self.imgnum = imgnum
+        self.excluded = False
+        s = 18
+        w = 3
+        rect = QtC.QRectF(-s, -s, 2 * s, 2 * s)
+        super().__init__(rect, parent)
+        color = QtG.QColor("blue")
+        pen = QtG.QPen(color, w)
+        self.setPen(pen)
+
+        self._line_1 = QtW.QGraphicsLineItem(-s, 0, s, 0, self)
+        self._line_1.setPen(pen)
+        self._line_2 = QtW.QGraphicsLineItem(0, -s, 0, s, self)
+        self._line_2.setPen(pen)
+
+        self._label = QtW.QGraphicsTextItem(f"{imgnum}", self)
+        self._label.setFont(QtG.QFont("Arial", 30))
+        self._label.setDefaultTextColor(color)
+        self._label.setPos(30, -30)
+
+    def set_excluded(self, excluded):
+        self.excluded = excluded
+        pen = self.pen()
+        color = pen.color()
+        color.setAlpha(85 if excluded else 255)
+        pen.setColor(color)
+        self.setPen(pen)
+        self._line_1.setPen(pen)
+        self._line_2.setPen(pen)
 
 
 class FidLight(QtW.QGraphicsEllipseItem):
@@ -218,3 +268,249 @@ class MonBox(QtW.QGraphicsRectItem):
         super().__init__(-(hw * 2), -(hw * 2), hw * 4, hw * 4, parent)
         self.setPen(QtG.QPen(QtG.QColor(255, 165, 0), w))
         self.setPos(star["row"], -star["col"])
+
+
+class FieldOfView(QtW.QGraphicsItem):
+    def __init__(self, attitude=None, alternate_outline=False):
+        super().__init__()
+        self.camera_outline = None
+        self.alternate_outline = alternate_outline
+        self.attitude = attitude
+        self.centroids = [Centroid(i, parent=self) for i in range(8)]
+        self._centroids = np.array(
+            [(0, 511, 511, 511, 511, 14, 0, 0, 0, 0) for _ in self.centroids],
+            dtype=[
+                ("IMGNUM", int),
+                ("IMGROW0_8X8", float),
+                ("IMGCOL0_8X8", float),
+                ("IMGROW0", int),
+                ("IMGCOL0", int),
+                ("AOACMAG", float),
+                ("YAGS", float),
+                ("ZAGS", float),
+                ("IMGFID", bool),
+                ("excluded", bool),
+            ],
+        )
+        self._centroids["IMGNUM"] = np.arange(8)
+        self.show_centroids = True
+        self.setZValue(80)
+
+    def get_attitude(self):
+        return self._attitude
+
+    def set_attitude(self, attitude):
+        if hasattr(self, "_attitude") and attitude == self._attitude:
+            return
+        self._attitude = attitude
+        if self.camera_outline is None:
+            self.camera_outline = CameraOutline(attitude, parent=self, simple=self.alternate_outline)
+        else:
+            self.camera_outline.attitude = attitude
+        if self.scene() is not None and self.scene().attitude is not None:
+            self.set_pos_for_attitude(self.scene().attitude)
+
+    attitude = property(get_attitude, set_attitude)
+
+    def set_pos_for_attitude(self, attitude):
+        if self.camera_outline is not None:
+            self.camera_outline.set_pos_for_attitude(attitude)
+        self._set_centroid_pos_for_attitude(attitude)
+
+    def _set_centroid_pos_for_attitude(self, attitude):
+        yag, zag = self._centroids["YAGS"], self._centroids["ZAGS"]
+        row0, col0 = yagzag_to_pixels(yag, zag, allow_bad=True)
+        if attitude != self.attitude:
+            # the first attitude is the attitude of this frame,
+            # so we first get the ra/dec pointed to by the centroids
+            # and then calculate the position in the scene coordinate system
+            # for those ra/dec values
+            ra, dec = yagzag_to_radec(yag, zag, self.attitude)
+            yag, zag = radec_to_yagzag(ra, dec, attitude)
+        row, col = yagzag_to_pixels(yag, zag, allow_bad=True)
+
+        off_ccd = (
+            (row0 < -511)
+            | (row0 > 511)
+            | (col0 < -511)
+            | (col0 > 511)
+            | (self._centroids["IMGFID"])
+        )
+        for i, centroid in enumerate(self.centroids):
+            if off_ccd[i]:
+                centroid.setVisible(False)
+            else:
+                centroid.setVisible(self._centroids_visible)
+            centroid.setPos(row[i], -col[i])
+
+    def boundingRect(self):
+        return QtC.QRectF(0, 0, 1, 1)
+
+    def paint(self, _painter, _option, _widget):
+        # this item draws nothing, it just holds children
+        pass
+
+    def set_centroids(self, centroids):
+        missing_cols = set(centroids.dtype.names) - set(self._centroids.dtype.names)
+        if missing_cols:
+            raise ValueError(f"Missing columns in centroids: {missing_cols}")
+
+        cols = list(centroids.dtype.names)
+        for col in cols:
+            self._centroids[col] = centroids[col]
+        self._set_centroid_pos_for_attitude(self.scene().attitude)
+
+    def set_show_centroids(self, show=True):
+        self._centroids_visible = show
+        row, col = yagzag_to_pixels(
+            self._centroids["YAGS"], self._centroids["ZAGS"], allow_bad=True
+        )
+        off_ccd = (
+            (row < -511)
+            | (row > 511)
+            | (col < -511)
+            | (col > 511)
+            | (self._centroids["IMGFID"])
+        )
+        for i, centroid in enumerate(self.centroids):
+            if off_ccd[i]:
+                centroid.setVisible(False)
+            else:
+                centroid.setVisible(show)
+
+    def get_show_centroids(self):
+        return self._centroids_visible
+
+    show_centroids = property(get_show_centroids, set_show_centroids)
+
+    def get_centroid_table(self):
+        self._centroids["MAG_ACA"] = [
+            (centroid.excluded or not centroid.isVisible())
+            for centroid in self.centroids
+        ]
+
+        table = Table()
+        table["IMGNUM"] = self._centroids["IMGNUM"]
+        table["MAG_ACA"] = self._centroids["MAG_ACA"]
+        table["excluded"] = self._centroids["MAG_ACA"]
+        table["YAG"] = self._centroids["YAGS"]
+        table["ZAG"] = self._centroids["ZAGS"]
+
+        return table
+
+
+class CameraOutline(QtW.QGraphicsItem):
+    def __init__(self, attitude, parent=None, simple=False):
+        super().__init__(parent)
+        self.simple = simple
+        self._frame = utils.get_camera_fov_frame()
+        self.attitude = attitude
+        self.setZValue(100)
+
+    def boundingRect(self):
+        # roughly half of the CCD size in arcsec (including some margin)
+        w = 2650
+        return QtC.QRectF(-w, -w, 2 * w, 2 * w)
+
+    def paint(self, painter, _option, _widget):
+        color = "lightGray" if self.simple else "black"
+        pen = QtG.QPen(QtG.QColor(color))
+        pen.setWidth(1)
+        pen.setCosmetic(True)
+
+        # I want to use antialising for these lines regardless of what is set for the scene,
+        # because they are large and otherwise look hideous. It will be reset at the end.
+        anti_aliasing_set = painter.testRenderHint(QtG.QPainter.Antialiasing)
+        painter.setRenderHint(QtG.QPainter.Antialiasing, True)
+
+        painter.setPen(pen)
+        for i in range(len(self._frame["edge_1"]["row"]) - 1):
+            painter.drawLine(
+                QtC.QPointF(
+                    self._frame["edge_1"]["row"][i], -self._frame["edge_1"]["col"][i]
+                ),
+                QtC.QPointF(
+                    self._frame["edge_1"]["row"][i + 1],
+                    -self._frame["edge_1"]["col"][i + 1],
+                ),
+            )
+        if self.simple:
+            painter.setRenderHint(QtG.QPainter.Antialiasing, anti_aliasing_set)
+            return
+
+        for i in range(len(self._frame["edge_2"]["row"]) - 1):
+            painter.drawLine(
+                QtC.QPointF(
+                    self._frame["edge_2"]["row"][i], -self._frame["edge_2"]["col"][i]
+                ),
+                QtC.QPointF(
+                    self._frame["edge_2"]["row"][i + 1],
+                    -self._frame["edge_2"]["col"][i + 1],
+                ),
+            )
+
+        for i in range(len(self._frame["cross_2"]["row"]) - 1):
+            painter.drawLine(
+                QtC.QPointF(
+                    self._frame["cross_2"]["row"][i], -self._frame["cross_2"]["col"][i]
+                ),
+                QtC.QPointF(
+                    self._frame["cross_2"]["row"][i + 1],
+                    -self._frame["cross_2"]["col"][i + 1],
+                ),
+            )
+        for i in range(len(self._frame["cross_1"]["row"]) - 1):
+            painter.drawLine(
+                QtC.QPointF(
+                    self._frame["cross_1"]["row"][i], -self._frame["cross_1"]["col"][i]
+                ),
+                QtC.QPointF(
+                    self._frame["cross_1"]["row"][i + 1],
+                    -self._frame["cross_1"]["col"][i + 1],
+                ),
+            )
+
+        painter.setRenderHint(QtG.QPainter.Antialiasing, anti_aliasing_set)
+
+    def set_pos_for_attitude(self, attitude):
+        """
+        Set the item position given the scene attitude.
+
+        Note that the given attitude is NOT the attitude of the camera corresponding to this frame.
+        It's the origin of the scene coordinate system.
+        """
+        if self._attitude is None:
+            raise Exception("FieldOfView attitude is not set. Can't set position.")
+        for key in self._frame:
+            # self._frame[key]["yag"] must not be modified
+            yag2, zag2 = radec_to_yagzag(
+                self._frame[key]["ra"], self._frame[key]["dec"], attitude
+            )
+            self._frame[key]["row"], self._frame[key]["col"] = yagzag_to_pixels(
+                yag2, zag2, allow_bad=True
+            )
+        self.update()
+
+    def set_attitude(self, attitude):
+        """
+        Set the attitude of the camera corresponding to this frame.
+
+        Note that this is not the attitude of the scene coordinate system.
+        """
+        if hasattr(self, "_attitude") and attitude == self._attitude:
+            return
+        self._attitude = attitude
+        if self._attitude is None:
+            for key in self._frame:
+                self._frame[key]["ra"] = None
+                self._frame[key]["dec"] = None
+        else:
+            for key in self._frame:
+                self._frame[key]["ra"], self._frame[key]["dec"] = yagzag_to_radec(
+                    self._frame[key]["yag"], self._frame[key]["zag"], self._attitude
+                )
+
+    def get_attitude(self):
+        return self._attitude
+
+    attitude = property(get_attitude, set_attitude)

--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -157,12 +157,12 @@ class Star(QtW.QGraphicsEllipseItem):
         return (
             "<pre>"
             f"ID:      {self.star['AGASC_ID']}\n"
-            f"mag:     {self.star['MAG_ACA']:.2f} +- {self.star['MAG_ACA_ERR']/100:.2}\n"
+            f"mag:     {self.star['MAG_ACA']:.2f} +- {self.star['MAG_ACA_ERR'] / 100:.2}\n"
             f"color:   {self.star['COLOR1']:.2f}\n"
             f"ASPQ1:   {self.star['ASPQ1']}\n"
             f"ASPQ2:   {self.star['ASPQ2']}\n"
             f"class:   {self.star['CLASS']}\n"
-            f"pos err: {self.star['POS_ERR']/1000} mas\n"
+            f"pos err: {self.star['POS_ERR'] / 1000} mas\n"
             f"VAR:     {self.star['VAR']}"
             "</pre>"
         )
@@ -576,12 +576,7 @@ class FieldOfView(QtW.QGraphicsItem):
         row, col = yagzag_to_pixels(
             self._centroids["YAGS"], self._centroids["ZAGS"], allow_bad=True
         )
-        off_ccd = (
-            (row < -511)
-            | (row > 511)
-            | (col < -511)
-            | (col > 511)
-        )
+        off_ccd = (row < -511) | (row > 511) | (col < -511) | (col > 511)
         for i, centroid in enumerate(self.centroids):
             centroid.set_fiducial(self._centroids["IMGFID"][i])
             if off_ccd[i]:

--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -270,7 +270,7 @@ class Centroid(QtW.QGraphicsEllipseItem):
         The parent item.
     """
 
-    def __init__(self, imgnum, parent=None):
+    def __init__(self, imgnum, parent=None, fiducial=False):
         self.imgnum = imgnum
         self.excluded = False
         s = 18
@@ -283,34 +283,32 @@ class Centroid(QtW.QGraphicsEllipseItem):
 
         s /= np.sqrt(2)
         self._line_1 = QtW.QGraphicsLineItem(-s, -s, s, s, self)
-        self._line_1.setPen(pen)
         self._line_2 = QtW.QGraphicsLineItem(s, -s, -s, s, self)
-        self._line_2.setPen(pen)
 
         self._label = QtW.QGraphicsTextItem(f"{imgnum}", self)
         self._label.setFont(QtG.QFont("Arial", 30))
-        self._label.setDefaultTextColor(color)
         self._label.setPos(30, -30)
+
+        self.fiducial = fiducial
+        self._set_style()
+
+    def _set_style(self):
+        color = QtG.QColor("red") if self.fiducial else QtG.QColor("blue")
+        color.setAlpha(85 if self.excluded else 255)
+        pen = self.pen()
+        pen.setColor(color)
+        self.setPen(pen)
+        self._line_1.setPen(pen)
+        self._line_2.setPen(pen)
+        self._label.setDefaultTextColor(color)
 
     def set_excluded(self, excluded):
         self.excluded = excluded
-        pen = self.pen()
-        color = pen.color()
-        color.setAlpha(85 if excluded else 255)
-        pen.setColor(color)
-        self.setPen(pen)
-        self._line_1.setPen(pen)
-        self._line_2.setPen(pen)
-        self._label.setDefaultTextColor(color)
+        self._set_style()
 
     def set_fiducial(self, fiducial):
-        color = QtG.QColor("red") if fiducial else QtG.QColor("blue")
-        pen = self.pen()
-        pen.setColor(color)
-        self.setPen(pen)
-        self._line_1.setPen(pen)
-        self._line_2.setPen(pen)
-        self._label.setDefaultTextColor(color)
+        self.fiducial = fiducial
+        self._set_style()
 
 
 class FidLight(QtW.QGraphicsEllipseItem):

--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -302,6 +302,14 @@ class Centroid(QtW.QGraphicsEllipseItem):
         self._line_1.setPen(pen)
         self._line_2.setPen(pen)
 
+    def set_fiducial(self, fiducial):
+        color = QtG.QColor("red") if fiducial else QtG.QColor("blue")
+        pen = self.pen()
+        pen.setColor(color)
+        self.setPen(pen)
+        self._line_1.setPen(pen)
+        self._line_2.setPen(pen)
+
 
 class FidLight(QtW.QGraphicsEllipseItem):
     """
@@ -571,9 +579,9 @@ class FieldOfView(QtW.QGraphicsItem):
             | (row > 511)
             | (col < -511)
             | (col > 511)
-            | (self._centroids["IMGFID"])
         )
         for i, centroid in enumerate(self.centroids):
+            centroid.set_fiducial(self._centroids["IMGFID"][i])
             if off_ccd[i]:
                 centroid.setVisible(False)
             else:

--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -301,6 +301,7 @@ class Centroid(QtW.QGraphicsEllipseItem):
         self.setPen(pen)
         self._line_1.setPen(pen)
         self._line_2.setPen(pen)
+        self._label.setDefaultTextColor(color)
 
     def set_fiducial(self, fiducial):
         color = QtG.QColor("red") if fiducial else QtG.QColor("blue")
@@ -309,6 +310,7 @@ class Centroid(QtW.QGraphicsEllipseItem):
         self.setPen(pen)
         self._line_1.setPen(pen)
         self._line_2.setPen(pen)
+        self._label.setDefaultTextColor(color)
 
 
 class FidLight(QtW.QGraphicsEllipseItem):

--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -451,6 +451,10 @@ class CameraOutline(QtW.QGraphicsItem):
                 ),
             )
 
+        magenta_pen = QtG.QPen(QtG.QColor("magenta"))
+        magenta_pen.setCosmetic(True)
+        magenta_pen.setWidth(1)
+        painter.setPen(magenta_pen)
         for i in range(len(self._frame["cross_2"]["row"]) - 1):
             painter.drawLine(
                 QtC.QPointF(

--- a/aperoll/star_field_items.py
+++ b/aperoll/star_field_items.py
@@ -32,14 +32,14 @@ __all__ = [
 
 
 def star_field_position(
-        attitude=None,
-        yag=None,
-        zag=None,
-        ra=None,
-        dec=None,
-        row=None,
-        col=None,
-    ):
+    attitude=None,
+    yag=None,
+    zag=None,
+    ra=None,
+    dec=None,
+    row=None,
+    col=None,
+):
     """
     Calculate the position of an item in the star_field.
 
@@ -118,6 +118,7 @@ class Star(QtW.QGraphicsEllipseItem):
     highlight : bool, optional
         If True, the star is highlighted in red.
     """
+
     def __init__(self, star, parent=None, highlight=False):
         s = symsize(star["MAG_ACA"])
         rect = QtC.QRectF(-s / 2, -s / 2, s, s)
@@ -268,6 +269,7 @@ class Centroid(QtW.QGraphicsEllipseItem):
     parent : QGraphicsItem, optional
         The parent item.
     """
+
     def __init__(self, imgnum, parent=None):
         self.imgnum = imgnum
         self.excluded = False
@@ -314,6 +316,7 @@ class FidLight(QtW.QGraphicsEllipseItem):
     parent : QGraphicsItem, optional
         The parent item.
     """
+
     def __init__(self, fid, parent=None):
         self.starcat_row = fid
         s = 27
@@ -343,6 +346,7 @@ class StarcatLabel(QtW.QGraphicsTextItem):
     parent : QGraphicsItem, optional
         The parent item.
     """
+
     def __init__(self, star, parent=None):
         self.starcat_row = star
         super().__init__(f"{star['idx']}", parent)
@@ -370,6 +374,7 @@ class GuideStar(QtW.QGraphicsEllipseItem):
     parent : QGraphicsItem, optional
         The parent item.
     """
+
     def __init__(self, star, parent=None):
         self.starcat_row = star
         s = 27
@@ -377,6 +382,7 @@ class GuideStar(QtW.QGraphicsEllipseItem):
         rect = QtC.QRectF(-s, -s, s * 2, s * 2)
         super().__init__(rect, parent)
         self.setPen(QtG.QPen(QtG.QColor("green"), w))
+
 
 class AcqStar(QtW.QGraphicsRectItem):
     """
@@ -391,6 +397,7 @@ class AcqStar(QtW.QGraphicsRectItem):
     parent : QGraphicsItem, optional
         The parent item.
     """
+
     def __init__(self, star, parent=None):
         self.starcat_row = star
         hw = star["halfw"] / 5
@@ -412,6 +419,7 @@ class MonBox(QtW.QGraphicsRectItem):
     parent : QGraphicsItem, optional
         The parent item.
     """
+
     def __init__(self, star, parent=None):
         self.starcat_row = star
         # starcheck convention was to plot monitor boxes at 2X halfw
@@ -437,6 +445,7 @@ class FieldOfView(QtW.QGraphicsItem):
     alternate_outline : bool, optional
         Boolean flag to use a simpler outline for the camera.
     """
+
     def __init__(self, attitude=None, alternate_outline=False):
         super().__init__()
         self.camera_outline = None
@@ -536,7 +545,9 @@ class FieldOfView(QtW.QGraphicsItem):
         centroids : astropy.table.Table
             A table with the following columns: IMGNUM, AOACMAG, YAGS, ZAGS, IMGFID.
         """
-        missing_cols = {"IMGNUM", "AOACMAG", "YAGS", "ZAGS", "IMGFID"} - set(centroids.dtype.names)
+        missing_cols = {"IMGNUM", "AOACMAG", "YAGS", "ZAGS", "IMGFID"} - set(
+            centroids.dtype.names
+        )
         if missing_cols:
             raise ValueError(f"Missing columns in centroids: {missing_cols}")
 
@@ -582,9 +593,7 @@ class FieldOfView(QtW.QGraphicsItem):
         table["ZAG"] = self._centroids["ZAGS"]
         table["IMGFID"] = self._centroids["IMGFID"]
         table["excluded"] = self._centroids["excluded"]
-        table["visible"] = [
-            centroid.isVisible() for centroid in self.centroids
-        ]
+        table["visible"] = [centroid.isVisible() for centroid in self.centroids]
 
         return table
 
@@ -599,6 +608,7 @@ class CameraOutline(QtW.QGraphicsItem):
     To calculate the position of the edges in the scene, the edges are first mapped to RA/dec,
     and these RA/dec are later used to calculate the position in the scene coordinate system.
     """
+
     def __init__(self, attitude, parent=None, simple=False):
         super().__init__(parent)
         self.simple = simple

--- a/aperoll/utils.py
+++ b/aperoll/utils.py
@@ -62,9 +62,9 @@ def get_camera_fov_frame():
         "col": cross_1[1],
     }
 
-    for key in frame:
-        frame[key]["yag"], frame[key]["zag"] = pixels_to_yagzag(
-            frame[key]["row"], frame[key]["col"], allow_bad=True
+    for value in frame.values():
+        value["yag"], value["zag"] = pixels_to_yagzag(
+            value["row"], value["col"], allow_bad=True
         )
 
     return frame

--- a/aperoll/utils.py
+++ b/aperoll/utils.py
@@ -1,5 +1,8 @@
 import numpy as np
-from chandra_aca.transform import pixels_to_yagzag, yagzag_to_pixels
+from chandra_aca.transform import (
+    pixels_to_yagzag,
+    yagzag_to_pixels,
+)
 from ska_helpers import logging
 
 logger = logging.basic_logger("aperoll")

--- a/aperoll/widgets/main_window.py
+++ b/aperoll/widgets/main_window.py
@@ -148,6 +148,7 @@ class MainWindow(QtW.QMainWindow):
         # self.plot.exclude_star.connect(self.parameters.exclude_star)
 
         self.parameters.do_it.connect(self._run_proseco)
+        self.plot.update_proseco.connect(self._run_proseco)
         self.parameters.run_sparkles.connect(self._run_sparkles)
         self.parameters.reset.connect(self._reset)
         self.parameters.draw_test.connect(self._draw_test)
@@ -181,6 +182,11 @@ class MainWindow(QtW.QMainWindow):
         if starcat is not None:
             self.plot.set_catalog(starcat)
             self.starcat_view.set_catalog(aca)
+            # make sure the catalog is not overwritten automatically
+            self.plot.scene.state.auto_proseco = False
+
+        if self.plot.scene.state.auto_proseco:
+            self._run_proseco()
 
     def closeEvent(self, event):
         if self.web_page is not None:
@@ -192,6 +198,8 @@ class MainWindow(QtW.QMainWindow):
         proseco_args = self.parameters.proseco_args()
         self.plot.set_base_attitude(proseco_args["att"])
         self._data.reset(proseco_args)
+        if self.plot.scene.state.auto_proseco and not self.plot.view.moving:
+            self._run_proseco()
 
     def _init(self):
         if self.parameters.values:
@@ -203,6 +211,7 @@ class MainWindow(QtW.QMainWindow):
             )
             self.plot.set_base_attitude(aca_attitude)
             self.plot.set_time(time)
+            self.plot.scene.state = "Proseco"
 
     def _reset(self):
         self.parameters.set_parameters(**self.opts)

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import agasc
 import numpy as np
@@ -442,13 +442,15 @@ class StarField(QtW.QGraphicsScene):
         return self._state
 
     def set_state(self, state_name):
-        self._state = self.states[state_name]
+        # copy self.states[state_name] so self.states[state_name] is not modified
+        self._state = replace(self.states[state_name])
 
         self.enable_fov(self._state.enable_fov)
         self.enable_alternate_fov(self._state.enable_alternate_fov)
         self.enable_catalog(self._state.enable_catalog)
         self.alternate_fov.show_centroids = self._state.enable_alternate_fov_centroids
         self.main_fov.show_centroids = self._state.enable_centroids
+        self.onboard_attitude_slot = self._state.onboard_attitude_slot
 
         self.state_changed.emit(state_name)
 

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -428,7 +428,9 @@ class StarField(QtW.QGraphicsScene):
         self.main_fov = FieldOfView()
         self.addItem(self.main_fov)
 
-        self.states = {value["name"]: StarFieldState(**value) for value in _COMMON_STATES}
+        self.states = {
+            value["name"]: StarFieldState(**value) for value in _COMMON_STATES
+        }
         self.set_state("Telemetry")
         if self.state.auto_proseco:
             self.update_proseco()

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -12,7 +12,13 @@ from PyQt5 import QtWidgets as QtW
 from Quaternion import Quat
 
 from aperoll import utils
-from aperoll.star_field_items import Catalog, Centroid, FieldOfView, Star, star_field_position
+from aperoll.star_field_items import (
+    Catalog,
+    Centroid,
+    FieldOfView,
+    Star,
+    star_field_position,
+)
 
 
 @dataclass
@@ -576,7 +582,7 @@ class StarField(QtW.QGraphicsScene):
             x, y = star_field_position(
                 self._attitude,
                 ra=self._stars["RA_PMCORR"],
-                dec=self._stars["DEC_PMCORR"]
+                dec=self._stars["DEC_PMCORR"],
             )
             for idx, item in enumerate(self._stars):
                 item["graphic_item"].setPos(x[idx], y[idx])

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -20,7 +20,7 @@ from aperoll.star_field_items import Catalog, Centroid, FieldOfView, Star
 
 
 @dataclass
-class State:
+class StarFieldState:
     """
     Dataclass to hold the state of the star field.
 
@@ -428,7 +428,7 @@ class StarField(QtW.QGraphicsScene):
         self.main_fov = FieldOfView()
         self.addItem(self.main_fov)
 
-        self.states = {value["name"]: State(**value) for value in _COMMON_STATES}
+        self.states = {value["name"]: StarFieldState(**value) for value in _COMMON_STATES}
         self.set_state("Telemetry")
         if self.state.auto_proseco:
             self.update_proseco()

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -69,7 +69,7 @@ _COMMON_STATES = [
     {
         # use case: "alternate" real-time telemetry
         # (attitude set to user attitude, but showing the camera outline in the alternate FOV)
-        "name": "Alternate",
+        "name": "Alternate FOV",
         "onboard_attitude_slot": "alternate_attitude",
         "enable_fov": True,
         "enable_alternate_fov": True,
@@ -98,21 +98,6 @@ class StarView(QtW.QGraphicsView):
         self._moving = False
 
         self._draw_frame = False
-
-        application = QtW.QApplication.instance()
-        main_windows = [
-            w for w in application.topLevelWidgets() if isinstance(w, QtW.QMainWindow)
-        ]
-        for window in main_windows:
-            menu_bar = window.menuBar()
-            menu = menu_bar.addMenu("Aperoll")
-            menu = menu.addMenu("Star Field Quick Config")
-            for state in self.scene().states.values():
-                action = QtW.QAction(state.name, self)
-                action.triggered.connect(
-                    lambda _checked, name=state.name: self.scene().set_state(name)
-                )
-                menu.addAction(action)
 
     def _get_draw_frame(self):
         return self._draw_frame
@@ -304,6 +289,12 @@ class StarView(QtW.QGraphicsView):
         reset_fov_action = QtW.QAction("Reset Alt FOV", menu, checkable=False)
         menu.addAction(reset_fov_action)
 
+        config_menu = menu.addMenu("Quick Config")
+
+        for state in self.scene().states.values():
+            action = QtW.QAction(state.name, config_menu)
+            config_menu.addAction(action)
+
         result = menu.exec_(event.globalPos())
         if result is not None:
             if centroid is not None and result.text().startswith("include slot"):
@@ -333,6 +324,8 @@ class StarView(QtW.QGraphicsView):
                 self.scene().state.auto_proseco = result.isChecked()
                 if result.isChecked():
                     self.update_proseco.emit()
+            elif result.text() in self.scene().states:
+                self.scene().set_state(result.text())
             else:
                 print(f"Action {result.text()} not implemented")
         event.accept()

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -740,6 +740,7 @@ class StarPlot(QtW.QWidget):
         if (
             self._catalog is not None
             and (len(self._catalog) == len(catalog))
+            and (self._catalog.dtype == catalog.dtype)
             and np.all(self._catalog == catalog)
         ):
             return

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -53,7 +53,7 @@ _COMMON_STATES = [
         "auto_proseco": False,
     },
     {
-        # use case: starndard aperoll use.
+        # use case: standard aperoll use.
         # (on-board attitude never updated, catalog on, centroids off, auto-proseco)
         "name": "Proseco",
         "onboard_attitude_slot": None,

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -718,7 +718,7 @@ class StarPlot(QtW.QWidget):
         """
         Sets the base attitude
 
-        The base attitude is the attitude corresponding to the origin of the scene.
+        The base attitude is the attitude of the scene.
         """
         self.scene.set_attitude(q)
 

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -66,7 +66,7 @@ _COMMON_STATES = [
     },
     {
         # use case: "alternate" real-time telemetry
-        # (attitude se to user attitude, but showing the camera outline in the alternate FOV)
+        # (attitude set to user attitude, but showing the camera outline in the alternate FOV)
         "name": "Alternate",
         "onboard_attitude_slot": "alternate_attitude",
         "enable_fov": True,

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -428,8 +428,6 @@ class StarField(QtW.QGraphicsScene):
             value["name"]: StarFieldState(**value) for value in _COMMON_STATES
         }
         self.set_state("Telemetry")
-        if self.state.auto_proseco:
-            self.update_proseco()
 
     def get_onboard_attitude_slot(self):
         return self.state.onboard_attitude_slot


### PR DESCRIPTION
## Description

The purpose of this PR is to:
- enable a simple real-time/telemetry use case together with aca_view.
- add a feature to automatically call proseco in the standard aperoll use.

This PR makes the following changes:
- Adds three graphics items:
  - Centroid. Markers for centroids from telemetry.
  - CameraOutline. A graphics item depicting the edges of the CCD and the quadrant boundaries.
  - FieldOfView. This is an item that contains a list of centroid items and a camera outline. It would be easy to also associate a catalog with it.
- Adds a function `star_field_position` that is used by all items to recalculate their position when the scene attitude changes.
- Adds a context menu to hide/show FOV, catalog and centroids.
- Puts all switches that determine `StarField` behavior into a dataclass of type `StarFieldState`. The idea is that this is the one place to find all run-time switches that the user can change.
- Adds an auto-proseco feature, which causes proseco to be run whenever the parameters change
- Changes `StarView` so `StarView.catalog` is never `None`, and adds `Catalog.reset` instead.


## Notes about testing/reviewing this PR

I would like to restrict this PR to the items mentioned above. I tried to keep the changes to the user interface as minimal as possible while still allowing me to toggle the item's visibility. This PR is not intended to make major changes in the UI. The main change is the addition of the context menu, which is not conspicuous. It should be functional though:
- one should be able to run in real-time and browse the star field (no proseco catalog)
- one should be able to evaluate difficult star fields the usual way and proseco should run automatically.
- one should be able to toggle visibility of the new items and they should behave as expected (centroids updated from telemetry, etc).

**One thing to note** is the `StarPLot.set_onboard_attitude` function.

## Requirements

This requires the latest agasc master (after sot/agasc/pull/193).

For real-time/telemetry use, use sot/aca_view/pull/197

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

The usual aperoll command to inspect catalogs
```
aperoll input.json
```

Usage within aca_view to inspect telemetry. in this case, I tried: showing/hiding different items, dragging the display, opening the star view before there is any telemetry. Note that the "auto-proseco" feature does not work in this case.
```
aca_view --obsid 42979 --stop 500
```