### PR TITLE
WIP: Explicitly cast some boolean arguments into bool

### DIFF
--- a/aperoll/widgets/centroid_table.py
+++ b/aperoll/widgets/centroid_table.py
@@ -127,7 +127,7 @@ class CentroidTable(TableWidget):
                 item = self._table[row][col]
                 if colname == "enable":
                     checkbox = self._q_table.cellWidget(row, col)
-                    checkbox.setChecked(item)
+                    checkbox.setChecked(bool(item))
                 else:
                     self._q_table.item(row, col).setText(
                         self.format[colname].format(item)

--- a/aperoll/widgets/star_plot.py
+++ b/aperoll/widgets/star_plot.py
@@ -664,18 +664,22 @@ class StarField(QtW.QGraphicsScene):
             self.alternate_attitude = attitude
 
     def enable_alternate_fov(self, enable=True):
+        enable = bool(enable)
         self.state.enable_alternate_fov = enable
         self.alternate_fov.setVisible(enable)
 
     def show_alternate_fov(self, show=True):
+        show = bool(show)
         if self.state.enable_alternate_fov:
             self.alternate_fov.setVisible(show)
 
     def enable_fov(self, enable=True):
+        enable = bool(enable)
         self.state.enable_fov = enable
         self.main_fov.setVisible(enable)
 
     def show_fov(self, show=True):
+        show = bool(show)
         if self.state.enable_fov:
             self.main_fov.setVisible(show)
 
@@ -684,10 +688,12 @@ class StarField(QtW.QGraphicsScene):
         self.alternate_fov.set_centroids(centroids)
 
     def enable_catalog(self, enable=True):
+        enable = bool(enable)
         self.state.enable_catalog = enable
         self.catalog.setVisible(enable)
 
     def show_catalog(self, show=True):
+        show = bool(show)
         if self.state.enable_catalog:
             self.catalog.setVisible(show)
 


### PR DESCRIPTION
## Description

This fixes some crashes when a Qt method with bool arguments takes a `np.bool` argument instead. This fixes the crashes I have found. It is not a general solution, and there could be other similar crashes.

Unfortunately, one error looks like this:
```
Traceback (most recent call last):
  File "/Users/javierg/SAO/git/aperoll/aperoll/widgets/star_plot.py", line 379, in set_visibility
    self.scene().show_fov(radius < 6)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/Users/javierg/SAO/git/aperoll/aperoll/widgets/star_plot.py", line 680, in show_fov
    self.main_fov.setVisible(show)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
TypeError: setVisible(self, visible: bool): argument 1 has unexpected type 'numpy.bool'
```

In this case, just because `radius` is an `np.float`, `radius < 6` will be `np.bool`. This is then passed to `FieldOfView.setVisible`, which is the inherited `QGraphicsItem.setVisible`,and this one takes a `bool` argument. The difference in type causes an exception.

Considering that numpy types are everywhere, one has to:
- override the method in derived classes so numpy types are cast in acceptable types
- and/or make sure values passed are not numpy types anywhere

This PR does the second in a few instances. Several methods that take a bool as argument will cast it explictly before passing it to `setVisible`. This means littering the code with bool casts, just because a numpy type _might_ be passed. Not nice.

Overriding the methods is not nice either. It would mean that every class that inherits from QGraphicsItem needs to have a `setVisible` method where the argument is cast and the `QGraphicsItem.setVisible` is called.

Then the question is to what other methods and types this applies. There doesn't seem to be an issue with float arguments. I do not know if this is caused by changes in numpy or by changes in the Qt python bindings.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
